### PR TITLE
Fix #15: typography default color

### DIFF
--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Typography.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Typography.kt
@@ -20,7 +20,7 @@ enum class MTypographyAlign {
 
 @Suppress("EnumEntryName")
 enum class MTypographyColor {
-    default, error, inherit, primary, secondary, textPrimary, textSecondary
+    initial, error, inherit, primary, secondary, textPrimary, textSecondary
 }
 
 @Suppress("EnumEntryName")
@@ -61,7 +61,7 @@ interface MTypographyProps : StyledProps {
 fun RBuilder.mTypography(
         text: String? = null,
         variant: MTypographyVariant = MTypographyVariant.body1,
-        color: MTypographyColor = MTypographyColor.default,
+        color: MTypographyColor = MTypographyColor.initial,
         align: MTypographyAlign = MTypographyAlign.left,
         gutterBottom: Boolean = false,
         noWrap: Boolean = false,


### PR DESCRIPTION
'default' value for Typography color has been changed to 'initial' in Material-UI and now warning appears when using Typography without specifying color other than 'default'.
This commit fixes it by changing 'default' to 'initial' in Typography.kt.

Regards,
Karol