### PR TITLE
Add Alert Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ typings/
 /muirwik-components/.gradle/
 /.gradle/
 /build/
+
+# Intellij
+.idea

--- a/muirwik-components/build.gradle.kts
+++ b/muirwik-components/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.jetbrains", "kotlin-styled", "1.0.0-$kotlinJsVersion")
 
     implementation(npm("@material-ui/core", "^4.11.0"))
+    implementation(npm("@material-ui/lab", "4.0.0-alpha.56"))
     implementation(npm("@material-ui/icons", "^4.9.1"))
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Alert.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Alert.kt
@@ -1,0 +1,54 @@
+package com.ccfraser.muirwik.components
+
+import org.w3c.dom.events.Event
+import react.RBuilder
+import react.RComponent
+import react.RProps
+import react.RState
+import react.ReactElement
+import styled.StyledHandler
+
+@JsModule("@material-ui/lab/Alert")
+private external val alertModule: dynamic
+
+@Suppress("UnsafeCastFromDynamic")
+private val alertComponent: RComponent<MAlertProps, RState> = alertModule.default
+
+@Suppress("EnumEntryName")
+enum class MAlertVariant {
+  filled, outlined, standard
+}
+
+@Suppress("EnumEntryName")
+enum class MAlertSeverity {
+  error, info, success, warning
+}
+
+interface MAlertProps : StyledPropsWithCommonAttributes {
+  var action: ReactElement
+  var icon: ReactElement
+  var onClose: (Event) -> Unit
+  var closeText: String
+}
+
+var MAlertProps.variant by EnumPropToStringNullable(MAlertVariant.values())
+var MAlertProps.severity by EnumPropToStringNullable(MAlertSeverity.values())
+
+fun RBuilder.mAlert(
+    message: String?,
+    variant: MAlertVariant = MAlertVariant.filled,
+    severity: MAlertSeverity = MAlertSeverity.success,
+    closeText: String = "Close",
+    onClose: ((Event) -> Unit)? = null,
+    addAsChild: Boolean = true,
+
+    className: String? = null,
+    handler: StyledHandler<MAlertProps>? = null) = createStyled(alertComponent, addAsChild) {
+  message?.let { +message }
+  attrs.variant = variant
+  attrs.severity = severity
+  attrs.closeText = closeText
+  onClose?.let { attrs.onClose = onClose }
+
+  setStyledPropsAndRunHandler(className, handler)
+}

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Snackbar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Snackbar.kt
@@ -64,7 +64,7 @@ var MSnackbarProps.transitionDuration by TransitionDurationDelegate()
 
 
 fun RBuilder.mSnackbar(
-        message: ReactElement,
+        message: ReactElement?,
         open: Boolean? = null,
         onClose: ((Event, MSnackbarOnCloseReason) -> Unit)? = null,
         horizAnchor: MSnackbarHorizAnchor = MSnackbarHorizAnchor.center,
@@ -79,7 +79,7 @@ fun RBuilder.mSnackbar(
     attrs.anchorOriginVertical = vertAnchor
     autoHideDuration?.let { attrs.autoHideDuration = it }
     key?.let { attrs.key = it }
-    attrs.message = message
+    message?.let { attrs.message = message}
     attrs.onClose = onClose
     open?.let { attrs.open = it }
     resumeHideDuration?.let { attrs.resumeHideDuration = it }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Snackbar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Snackbar.kt
@@ -62,7 +62,9 @@ var MSnackbarProps.onClose by OnClosePropWithReasonDelegate(MSnackbarOnCloseReas
 var MSnackbarProps.transitionComponent by TransitionComponentDelegate()
 var MSnackbarProps.transitionDuration by TransitionDurationDelegate()
 
-
+/**
+ * Base builder for Snackbar.
+ */
 fun RBuilder.mSnackbar(
         message: ReactElement?,
         open: Boolean? = null,
@@ -88,7 +90,7 @@ fun RBuilder.mSnackbar(
 }
 
 /**
- * Just one with a string for the message
+ * Builder for Snackbar with a message of type string.
  */
 fun RBuilder.mSnackbar(
         message: String,
@@ -106,4 +108,24 @@ fun RBuilder.mSnackbar(
     val dynamicElement: ReactElement = message.asDynamic()
     return mSnackbar(dynamicElement, open, onClose, horizAnchor, vertAnchor, key, autoHideDuration, resumeHideDuration,
             className, handler)
+}
+
+
+/**
+ * Builder for Snackbar without message as the content is based on the child.
+ */
+fun RBuilder.mSnackbar(
+    open: Boolean? = null,
+    onClose: ((Event, MSnackbarOnCloseReason) -> Unit)? = null,
+    horizAnchor: MSnackbarHorizAnchor = MSnackbarHorizAnchor.center,
+    vertAnchor: MSnackbarVertAnchor = MSnackbarVertAnchor.bottom,
+    key: String? = null,
+    autoHideDuration: Int? = null,
+    resumeHideDuration: Int? = null,
+
+    className: String? = null,
+    handler: StyledHandler<MSnackbarProps>? = null): ReactElement {
+    @Suppress("UnsafeCastFromDynamic")
+    return mSnackbar(null, open, onClose, horizAnchor, vertAnchor, key, autoHideDuration, resumeHideDuration,
+        className, handler)
 }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
@@ -35,6 +35,7 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
     private val nameToTestMap = hashMapOf(
             "Intro" to RBuilder::intro,
             "Accordion" to RBuilder::testAccordion,
+            "Alert" to RBuilder::testAlert,
             "App Bar" to RBuilder::testAppBar,
             "Avatars" to RBuilder::testAvatars,
             "Badges" to RBuilder::testBadges,

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestAlert.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestAlert.kt
@@ -38,7 +38,7 @@ class TestAlert : RComponent<RProps, RState>() {
         css(margin)
       }
 
-      mSnackbar(null, open = open) {
+      mSnackbar(open = open) {
         mAlert("Snackbar Alert")
       }
     }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestAlert.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestAlert.kt
@@ -1,0 +1,49 @@
+package com.ccfraser.muirwik.testapp
+
+import com.ccfraser.muirwik.components.MAlertSeverity
+import com.ccfraser.muirwik.components.button.MButtonVariant
+import com.ccfraser.muirwik.components.button.mButton
+import com.ccfraser.muirwik.components.mAlert
+import com.ccfraser.muirwik.components.mSnackbar
+import com.ccfraser.muirwik.components.spacingUnits
+import com.ccfraser.muirwik.testapp.TestAlert.CustomStyles.margin
+import kotlinx.css.margin
+import react.RBuilder
+import react.RComponent
+import react.RProps
+import react.RState
+import react.dom.div
+import react.setState
+import styled.StyleSheet
+import styled.css
+
+class TestAlert : RComponent<RProps, RState>() {
+  private object CustomStyles : StyleSheet("ComponentStyles", isStatic = true) {
+    val margin by css {
+      margin(1.spacingUnits)
+    }
+  }
+
+  var open = false
+
+  override fun RBuilder.render() {
+    div {
+      MAlertSeverity.values().forEach { severity ->
+        mAlert("This is a ${severity.name} alert", severity = severity) {
+          css(margin)
+        }
+      }
+
+      mButton("click me", onClick = { setState { open = true } }, variant = MButtonVariant.outlined) {
+        css(margin)
+      }
+
+      mSnackbar(null, open = open) {
+        mAlert("Snackbar Alert")
+      }
+    }
+  }
+
+}
+
+fun RBuilder.testAlert() = child(TestAlert::class) {}


### PR DESCRIPTION
Hi, thanks for the awesome library. I know everything is still WIP, so I thought I would make some contributions while using it. 

I currently need to use the Alert component which does not yet have any wrapper. So I  just created one. 

Let me know if you have any feedback or requested changes. Especially in regards to the dependency to `material-ui/lab`. Not sure if you don't want to depend on the experimental library or if you just didn't get to create wrappers for it yet.