### PR TITLE
Introduce IR compiler

### DIFF
--- a/muirwik-components/build.gradle.kts
+++ b/muirwik-components/build.gradle.kts
@@ -36,11 +36,7 @@ dependencies {
 }
 
 kotlin {
-    defaultJsCompilerType = KotlinJsCompilerType.LEGACY  // The default
-//    defaultJsCompilerType = KotlinJsCompilerType.IR
-//    defaultJsCompilerType = KotlinJsCompilerType.BOTH
-
-    js {
+    js(IR) {
         browser {
             webpackTask {
                 cssSupport.enabled = true
@@ -79,7 +75,7 @@ publishing {
         create<MavenPublication>(publicationName) {
             from(components["kotlin"])
 //            artifact(tasks["KDocJar"])
-            artifact(tasks.getByName<Zip>("jsSourcesJar"))
+//            artifact(tasks.getByName<Zip>("jsSourcesJar"))
 
             pom {
                 name.set("Muirwik Components")

--- a/muirwik-components/build.gradle.kts
+++ b/muirwik-components/build.gradle.kts
@@ -75,7 +75,7 @@ publishing {
         create<MavenPublication>(publicationName) {
             from(components["kotlin"])
 //            artifact(tasks["KDocJar"])
-//            artifact(tasks.getByName<Zip>("jsSourcesJar"))
+            artifact(tasks.getByName<Zip>("jsSourcesJar"))
 
             pom {
                 name.set("Muirwik Components")

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Appbar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Appbar.kt
@@ -21,7 +21,7 @@ enum class MAppBarColor {
     default, inherit, primary, secondary, transparent
 }
 
-interface MAppBarProps : StyledPropsWithCommonAttributes
+external interface MAppBarProps : StyledPropsWithCommonAttributes
 var MAppBarProps.color by EnumPropToString(MAppBarColor.values())
 var MAppBarProps.position by EnumPropToString(MAppBarPosition.values())
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Appbar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Appbar.kt
@@ -37,4 +37,3 @@ fun RBuilder.mAppBar(
 
     setStyledPropsAndRunHandler(className, handler)
 }
-

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Avatar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Avatar.kt
@@ -17,7 +17,7 @@ enum class MAvatarVariant {
     circle, rounded, square
 }
 
-interface MAvatarProps : StyledPropsWithCommonAttributes {
+external interface MAvatarProps : StyledPropsWithCommonAttributes {
     var alt: String
     var component: String
     var imgProps: RProps

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Backdrop.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Backdrop.kt
@@ -15,7 +15,7 @@ private external val backdropModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val backdropComponent: RComponent<MBackdropProps, RState> = backdropModule.default
 
-interface MBackdropProps : MFadeProps, ReactHtmlElementEvents {
+external interface MBackdropProps : MFadeProps, ReactHtmlElementEvents {
     var invisible: Boolean
     var open: Boolean
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Badge.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Badge.kt
@@ -39,7 +39,7 @@ enum class MBadgeAnchorOriginVertical {
 }
 
 
-interface MBadgeProps: StyledPropsWithCommonAttributes {
+external interface MBadgeProps: StyledPropsWithCommonAttributes {
     var badgeContent: ReactElement
     var component: String
     var invisible: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Base.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Base.kt
@@ -104,6 +104,7 @@ fun CSSBuilder.toolbarJsCssToPartialCss(jsObject: Object) {
 
 
 //class EmptyProps : RProps
+@JsExport
 class PropsWithJsStyle(var style: Object?) : RProps
 
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/BottomNavigation.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/BottomNavigation.kt
@@ -16,7 +16,7 @@ private external val bottomNavigationModule: dynamic
 private val bottomNavigationComponent: RComponent<MBottomNavigationProps, RState> = bottomNavigationModule.default
 
 
-interface MBottomNavigationProps: StyledPropsWithCommonAttributes {
+external interface MBottomNavigationProps: StyledPropsWithCommonAttributes {
     var component: String
     var onChange: (event: Event, value: Any) -> Unit
     var showLabels: Boolean
@@ -46,7 +46,7 @@ private external val bottomNavigationActionModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val bottomNavigationActionComponent: RComponent<MBottomNavigationActionProps, RState> = bottomNavigationActionModule.default
 
-interface MBottomNavigationActionProps: MButtonBaseProps {
+external interface MBottomNavigationActionProps: MButtonBaseProps {
     var icon: ReactElement
     var label: ReactElement
     var showLabel: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Breadcrumbs.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Breadcrumbs.kt
@@ -13,7 +13,7 @@ private external val breadcrumbsModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val breadcrumbsComponent: RComponent<MBreadcrumbsProps, RState> = breadcrumbsModule.default
 
-interface MBreadcrumbsProps: StyledPropsWithCommonAttributes {
+external interface MBreadcrumbsProps: StyledPropsWithCommonAttributes {
     var component: String
     var itemsAfterCollapse: Int
     var itemsBeforeCollapse: Int

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Checkbox.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Checkbox.kt
@@ -16,7 +16,7 @@ private external val checkboxModule: dynamic
 private val checkboxComponent : RComponent<MCheckboxProps, RState> = checkboxModule.default
 
 
-interface MCheckboxProps : StyledPropsWithCommonAttributes {
+external interface MCheckboxProps : StyledPropsWithCommonAttributes {
     var checked: Boolean
     var checkedIcon: ReactElement
     var disabled: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Chip.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Chip.kt
@@ -29,7 +29,7 @@ enum class MChipSize {
     small, medium
 }
 
-interface MChipProps : StyledPropsWithCommonAttributes {
+external interface MChipProps : StyledPropsWithCommonAttributes {
     var avatar: ReactElement
     var clickable: Boolean
     var component: String

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/CircularProgress.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/CircularProgress.kt
@@ -25,7 +25,7 @@ enum class MCircularProgressVariant {
     determinate, indeterminate, static
 }
 
-interface MCircularProgressProps : StyledProps {
+external interface MCircularProgressProps : StyledProps {
     var disableShrink: Boolean
     var thickness: Double
     var value: Double

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ClickAwayListener.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ClickAwayListener.kt
@@ -27,7 +27,7 @@ enum class MClickAwayListenerTouchEvent {
     fun value() = if (this == disable) false else super.toString()
 }
 
-interface MClickAwayListenerProps : StyledProps {
+external interface MClickAwayListenerProps : StyledProps {
     var onClickAway: () -> Unit
 }
 var MClickAwayListenerProps.mouseEvent: MClickAwayListenerMouseEvent

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Container.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Container.kt
@@ -14,7 +14,7 @@ private external val containerModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val containerComponent: RComponent<MContainerProps, RState> = containerModule.default
 
-interface MContainerProps : StyledProps {
+external interface MContainerProps : StyledProps {
     var component: String
     var disableGutters: Boolean
     var fixed: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Divider.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Divider.kt
@@ -23,7 +23,7 @@ enum class MDividerVariant {
     fullWidth, inset, middle
 }
 
-interface MDividerProps : StyledProps {
+external interface MDividerProps : StyledProps {
     var absolute: Boolean
     var component: String
     var light: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Drawer.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Drawer.kt
@@ -27,7 +27,7 @@ enum class MDrawerVariant {
     permanent, persistent, temporary
 }
 
-interface MDrawerProps : StyledPropsWithCommonAttributes {
+external interface MDrawerProps : StyledPropsWithCommonAttributes {
     var elevation: Int
 
     @JsName("ModalProps")

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Grid.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Grid.kt
@@ -148,7 +148,7 @@ data class MGridBreakpoints(
 }
 
 
-interface MGridProps : StyledProps {
+external interface MGridProps : StyledProps {
     var component: String
     var container: Boolean
     var item: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Hidden.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Hidden.kt
@@ -19,7 +19,7 @@ enum class MHiddenImplementation {
     js, css
 }
 
-interface MHiddenProps : StyledProps {
+external interface MHiddenProps : StyledProps {
     var lgDown: Boolean
     var lgUp: Boolean
     var mdDown: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Icon.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Icon.kt
@@ -23,7 +23,7 @@ enum class MIconFontSize {
     inherit, default, small, large
 }
 
-interface MIconProps : StyledProps {
+external interface MIconProps : StyledProps {
 //    var style: Object
     var component: String?
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/LinearProgress.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/LinearProgress.kt
@@ -23,7 +23,7 @@ enum class MLinearProgressVariant {
     determinate, indeterminate, buffer, query
 }
 
-interface MLinearProgressProps : StyledProps {
+external interface MLinearProgressProps : StyledProps {
     var value: Double
     var valueBuffer: Double
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Link.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Link.kt
@@ -15,7 +15,7 @@ enum class MLinkUnderline {
     none, hover, always
 }
 
-interface MLinkProps: MTypographyProps {
+external interface MLinkProps: MTypographyProps {
     var block: Boolean
 
     @JsName("TypographyClasses")

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/MuiThemeProvider.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/MuiThemeProvider.kt
@@ -10,7 +10,7 @@ private external val muiThemeProviderModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val muiThemeProviderComponent: RComponent<MuiThemeProviderProps, RState> = muiThemeProviderModule.ThemeProvider
 
-interface MuiThemeProviderProps : RProps {
+external interface MuiThemeProviderProps : RProps {
     var disableStylesGeneration: Boolean
     var sheetsManager: Any
     var theme: Theme

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/NativeSelect.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/NativeSelect.kt
@@ -13,7 +13,7 @@ private external val nativeSelectModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val nativeSelectComponent: RComponent<MNativeSelectProps, RState> = nativeSelectModule.default
 
-interface MNativeSelectProps : StyledPropsWithCommonAttributes {
+external interface MNativeSelectProps : StyledPropsWithCommonAttributes {
     var autoFocus: Boolean
     var disabled: Boolean
     var error: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Paper.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Paper.kt
@@ -18,7 +18,7 @@ enum class MPaperVariant {
     elevation, outlined
 }
 
-interface MPaperProps : StyledProps {
+external interface MPaperProps : StyledProps {
     var component: String
     var elevation: Int
     var square: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Popover.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Popover.kt
@@ -31,7 +31,7 @@ enum class MPopoverVerticalPosition {
     top, center, bottom
 }
 
-interface MPopoverProps : MModalProps {
+external interface MPopoverProps : MModalProps {
     var action: (actions: Object) -> Unit
     var anchorEl: Node?
     var elevation: Int

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Radio.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Radio.kt
@@ -17,7 +17,7 @@ private external val radioModule: dynamic
 private val radioComponent: RComponent<MRadioProps, RState> = radioModule.default
 
 
-interface MRadioProps : StyledPropsWithCommonAttributes {
+external interface MRadioProps : StyledPropsWithCommonAttributes {
     var checked: Boolean
     var checkedIcon: ReactElement?
     var disabled: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Radio.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Radio.kt
@@ -89,7 +89,7 @@ private external val radioGroupModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val radioGroupComponent: RComponent<MRadioGroupProps, RState> = radioGroupModule.default
 
-interface MRadioGroupProps : MFormGroupProps {
+external interface MRadioGroupProps : MFormGroupProps {
     var name: String?
     var onChange: ((Event, String) -> Unit)?
     var value: String?

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ReactHtmlElementAttributes.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ReactHtmlElementAttributes.kt
@@ -21,7 +21,7 @@ enum class DropZone {
     copy, move, link
 }
 
-interface ReactHtmlElementAttributes : RProps {
+external interface ReactHtmlElementAttributes : RProps {
     var accessKey: String
     var autoCapitalize: AutoCapitalize
 //    var class: String

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ReactHtmlElementEvents.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ReactHtmlElementEvents.kt
@@ -14,7 +14,7 @@ import react.RProps
  * Since most of the Material UI components pass on any props to the underlying element, this makes it easier
  * to set them if required.
  */
-interface ReactHtmlElementEvents : RProps {
+external interface ReactHtmlElementEvents : RProps {
     var onAbort: ((Event) -> Unit)?
     var onBlur: ((FocusEvent) -> Unit)?
     var onCanPlay: ((Event) -> Unit)?

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Select.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Select.kt
@@ -18,7 +18,7 @@ private val selectComponent: RComponent<MSelectProps, RState> = selectModule.def
  * the wrong function prototype for onChange. We introduce our own onChange here as well as the
  * displayUnderline prop which was the only thing (at time of writing) added to MInputProps.
  */
-interface MSelectProps : MInputBaseNoOnChangeProps {
+external interface MSelectProps : MInputBaseNoOnChangeProps {
     var autoWidth: Boolean
     var disableUnderline: Boolean
     var displayEmpty: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Slider.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Slider.kt
@@ -27,7 +27,7 @@ enum class MSliderValueLabelDisplay {
 
 data class MSliderMark(val value: Number, val label: String? = null)
 
-interface MSliderProps : StyledPropsWithCommonAttributes {
+external interface MSliderProps : StyledPropsWithCommonAttributes {
     var component: String
     var defaultValue: Any
     var disabled: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Snackbar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Snackbar.kt
@@ -29,7 +29,7 @@ enum class MSnackbarOnCloseReason {
     timeout, clickaway
 }
 
-interface MSnackbarProps : StyledProps {
+external interface MSnackbarProps : StyledProps {
     var action: ReactElement
 
     var autoHideDuration: Int

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/StyledPropsWithCommonAttributes.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/StyledPropsWithCommonAttributes.kt
@@ -2,4 +2,4 @@ package com.ccfraser.muirwik.components
 
 import styled.StyledProps
 
-interface StyledPropsWithCommonAttributes : StyledProps, ReactHtmlElementAttributes, ReactHtmlElementEvents
+external interface StyledPropsWithCommonAttributes : StyledProps, ReactHtmlElementAttributes, ReactHtmlElementEvents

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SvgIcon.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SvgIcon.kt
@@ -15,7 +15,7 @@ enum class SvgShapeRendering {
     auto, optimizeSpeed, crispEdges, geometricPrecision
 }
 
-interface MSvgIconProps : MIconProps {
+external interface MSvgIconProps : MIconProps {
     var htmlColor: String?
     var titleAccess: String?
     var viewBox: String?

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SvgIcon.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SvgIcon.kt
@@ -5,10 +5,10 @@ import react.*
 import styled.StyledHandler
 
 @JsModule("@material-ui/core/SvgIcon")
-private external val module: dynamic
+private external val svgIconModule: dynamic
 
 @Suppress("UnsafeCastFromDynamic")
-private val component: RComponent<MSvgIconProps, RState> = module.default
+private val svgIconComponent: RComponent<MSvgIconProps, RState> = svgIconModule.default
 
 @Suppress("EnumEntryName")
 enum class SvgShapeRendering {
@@ -30,7 +30,7 @@ fun RBuilder.mSvgIcon(
 
         addAsChild: Boolean = true,
         className: String? = null,
-        handler: StyledHandler<MSvgIconProps>? = null) = createStyled(component, addAsChild) {
+        handler: StyledHandler<MSvgIconProps>? = null) = createStyled(svgIconComponent, addAsChild) {
     attrs.color = color
     htmlColor?.let { attrs.htmlColor = it }
     attrs.fontSize = fontSize

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SwipeableDrawer.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SwipeableDrawer.kt
@@ -26,7 +26,7 @@ external interface MSwipeableDrawerProps : MDrawerProps {
     var swipeAreaWidth: Number
 }
 
-interface MSwipeAreaProps : StyledProps
+external interface MSwipeAreaProps : StyledProps
 
 fun RBuilder.mSwipeableDrawer(
         open: Boolean = false,

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SwipeableDrawer.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/SwipeableDrawer.kt
@@ -15,7 +15,7 @@ private external val swipeableDrawerModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val swipeableDrawerComponent: RComponent<MSwipeableDrawerProps, RState> = swipeableDrawerModule.default
 
-interface MSwipeableDrawerProps : MDrawerProps {
+external interface MSwipeableDrawerProps : MDrawerProps {
     var disableBackdropTransition: Boolean
     var disableDiscovery: Boolean
     var disableSwipeToOpen: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Switch.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Switch.kt
@@ -20,7 +20,7 @@ enum class MSwitchEdge {
     start, end // We assume if the prop is null, then the default false will be used, so we don't have this as a value
 }
 
-interface MSwitchProps : StyledPropsWithCommonAttributes {
+external interface MSwitchProps : StyledPropsWithCommonAttributes {
     var checked: Boolean
     var checkedIcon: ReactElement
     var disabled: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Tabs.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Tabs.kt
@@ -96,7 +96,7 @@ private external val tabModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val tabComponent: RComponent<MTabProps, RState> = tabModule.default
 
-interface MTabProps: MButtonBaseProps {
+external interface MTabProps: MButtonBaseProps {
     var disableFocusRipple: Boolean
     var icon: ReactElement
     var label: ReactElement

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Tabs.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Tabs.kt
@@ -9,6 +9,8 @@ import styled.StyledProps
 
 @JsModule("@material-ui/core/Tabs")
 private external val tabsModule: dynamic
+
+@Suppress("UnsafeCastFromDynamic")
 private val tabsComponent: RComponent<MTabsProps, RState> = tabsModule.default
 
 @Suppress("EnumEntryName")
@@ -36,7 +38,7 @@ enum class MTabOrientation {
     horizontal, vertical
 }
 
-interface MTabsProps: StyledProps {
+external interface MTabsProps: StyledProps {
     var action: (actions: Any) -> Unit
     var centered: Boolean
     var onChange: (event: Event, indexValue: Any) -> Unit

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/TextAeraAutosize.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/TextAeraAutosize.kt
@@ -13,7 +13,7 @@ private external val textAreaAutosizeDefault: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val textAreaAutosizeComponent: RComponent<MTextAreaAutosizeProps, RState> = textAreaAutosizeDefault.default
 
-interface MTextAreaAutosizeProps : MFormControlProps {
+external interface MTextAreaAutosizeProps : MFormControlProps {
     var rowsMax: Int
     var rowsMin: Int
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/TextField.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/TextField.kt
@@ -21,7 +21,7 @@ enum class MTextFieldColor {
     primary, secondary
 }
 
-interface MTextFieldProps : MFormControlProps {
+external interface MTextFieldProps : MFormControlProps {
     var autoComplete: String
     var autoFocus: Boolean
     var defaultValue: String

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ThemeProvider.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/ThemeProvider.kt
@@ -3,6 +3,7 @@ package com.ccfraser.muirwik.components
 import com.ccfraser.muirwik.components.styles.Theme
 import com.ccfraser.muirwik.components.styles.ThemeOptions
 import com.ccfraser.muirwik.components.styles.createMuiTheme
+import com.ccfraser.muirwik.components.styles.invoke
 import kotlinx.css.px
 import react.*
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Toolbar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Toolbar.kt
@@ -21,7 +21,7 @@ enum class ToolbarVariant {
     regular, dense
 }
 
-interface MToolbarProps : StyledProps {
+external interface MToolbarProps : StyledProps {
     var disableGutters: Boolean
 }
 var MToolbarProps.variant by EnumPropToString(ToolbarVariant.values())

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Tooltip.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Tooltip.kt
@@ -23,7 +23,7 @@ enum class TooltipPlacement {
     }
 }
 
-interface MTooltipProps : StyledPropsWithCommonAttributes {
+external interface MTooltipProps : StyledPropsWithCommonAttributes {
     var arrow: Boolean
     var disableFocusListener: Boolean
     var disableHoverListener: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Typography.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/Typography.kt
@@ -27,7 +27,7 @@ enum class MTypographyVariant {
     h1, h2, h3, h4, h5, h6, subtitle1, subtitle2, body1, body2, caption, button, overline, srOnly, inherit
 }
 
-interface MTypographyProps : StyledPropsWithCommonAttributes {
+external interface MTypographyProps : StyledPropsWithCommonAttributes {
     var component: String
     var gutterBottom: Boolean
     var noWrap: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/Accordion.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/Accordion.kt
@@ -17,7 +17,7 @@ private external val module: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val component: RComponent<MAccordionProps, RState> = module.default
 
-interface MAccordionProps : StyledPropsWithCommonAttributes {
+external interface MAccordionProps : StyledPropsWithCommonAttributes {
 	var defaultExpanded: Boolean
 	var disabled: Boolean
 	var expanded: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/Accordion.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/Accordion.kt
@@ -12,10 +12,10 @@ import react.RState
 import styled.StyledHandler
 
 @JsModule("@material-ui/core/Accordion")
-private external val module: dynamic
+private external val accordionModule: dynamic
 
 @Suppress("UnsafeCastFromDynamic")
-private val component: RComponent<MAccordionProps, RState> = module.default
+private val accordionComponent: RComponent<MAccordionProps, RState> = accordionModule.default
 
 external interface MAccordionProps : StyledPropsWithCommonAttributes {
 	var defaultExpanded: Boolean
@@ -37,7 +37,7 @@ fun RBuilder.mAccordion(
 		square: Boolean = false,
 		onChange: ((Event, Boolean) -> Unit)? = null,
 		className: String? = null,
-		handler: StyledHandler<MAccordionProps>? = null) = createStyled(component) {
+		handler: StyledHandler<MAccordionProps>? = null) = createStyled(accordionComponent) {
 			attrs.defaultExpanded = defaultExpanded
 			attrs.disabled = disabled
 			attrs.square = square

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionActions.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionActions.kt
@@ -14,7 +14,7 @@ private external val module: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val component: RComponent<MAccordionActionsProps, RState> = module.default
 
-interface MAccordionActionsProps : StyledPropsWithCommonAttributes {
+external interface MAccordionActionsProps : StyledPropsWithCommonAttributes {
 	var disableSpacing: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionDetails.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionDetails.kt
@@ -9,13 +9,13 @@ import styled.StyledHandler
 import styled.StyledProps
 
 @JsModule("@material-ui/core/AccordionDetails")
-private external val module: dynamic
+private external val accordionDetailsModule: dynamic
 
 @Suppress("UnsafeCastFromDynamic")
-private val component: RComponent<StyledProps, RState> = module.default
+private val accordionDetailsComponent: RComponent<StyledProps, RState> = accordionDetailsModule.default
 
 fun RBuilder.mAccordionDetails(
 		className: String? = null,
-		handler: StyledHandler<StyledProps>? = null) = createStyled(component) {
+		handler: StyledHandler<StyledProps>? = null) = createStyled(accordionDetailsComponent) {
 			setStyledPropsAndRunHandler(className, handler)
 		}

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionSummary.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionSummary.kt
@@ -7,10 +7,10 @@ import react.*
 import styled.StyledHandler
 
 @JsModule("@material-ui/core/AccordionSummary")
-private external val module: dynamic
+private external val accordionSummaryModule: dynamic
 
 @Suppress("UnsafeCastFromDynamic")
-private val component: RComponent<MAccordionSummaryProps, RState> = module.default
+private val accordionSummaryComponent: RComponent<MAccordionSummaryProps, RState> = accordionSummaryModule.default
 
 external interface MAccordionSummaryProps : StyledPropsWithCommonAttributes {
 	var expandIcon: ReactElement
@@ -21,7 +21,7 @@ fun RBuilder.mAccordionSummary(
 		expandIcon: ReactElement? = null,
 		iconButtonProps: RProps? = null,
 		className: String? = null,
-		handler: StyledHandler<MAccordionSummaryProps>? = null) = createStyled(component) {
+		handler: StyledHandler<MAccordionSummaryProps>? = null) = createStyled(accordionSummaryComponent) {
 			expandIcon?.let { attrs.expandIcon = it }
 			iconButtonProps?.let { attrs.iconButtonProps = it }
 			setStyledPropsAndRunHandler(className, handler)

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionSummary.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/accordion/AccordionSummary.kt
@@ -12,7 +12,7 @@ private external val module: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val component: RComponent<MAccordionSummaryProps, RState> = module.default
 
-interface MAccordionSummaryProps : StyledPropsWithCommonAttributes {
+external interface MAccordionSummaryProps : StyledPropsWithCommonAttributes {
 	var expandIcon: ReactElement
 	var iconButtonProps: RProps
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/Button.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/Button.kt
@@ -16,7 +16,7 @@ private external val buttonModule: dynamic
 private val buttonComponent: RComponent<MButtonProps, RState> = buttonModule.default
 
 
-interface MButtonProps : MButtonBaseProps {
+external interface MButtonProps : MButtonBaseProps {
     var disableFocusRipple: Boolean
     var disableElevation: Boolean
     var endIcon: ReactElement

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/ButtonBase.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/ButtonBase.kt
@@ -5,7 +5,7 @@ import org.w3c.dom.events.Event
 import react.RProps
 
 
-interface MButtonBaseProps: StyledPropsWithCommonAttributes {
+external interface MButtonBaseProps: StyledPropsWithCommonAttributes {
     var centerRipple: Boolean
     var component: String
     var disabled: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/ButtonGroup.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/ButtonGroup.kt
@@ -21,7 +21,7 @@ enum class MButtonGroupOrientation {
     vertical, horizontal
 }
 
-interface MButtonGroupProps : StyledPropsWithCommonAttributes {
+external interface MButtonGroupProps : StyledPropsWithCommonAttributes {
     var component: String
     var disabled: Boolean
     var disableElevation: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/FabButton.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/FabButton.kt
@@ -19,7 +19,7 @@ enum class MFabVariant {
     round, extended
 }
 
-interface MFabProps : MButtonBaseProps {
+external interface MFabProps : MButtonBaseProps {
     var disableFocusRipple: Boolean
     var href: String
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/IconButton.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/button/IconButton.kt
@@ -23,7 +23,7 @@ enum class MIconEdge {
     start, end // We assume if the prop is null, then the default false will be used, so we don't have this as a value
 }
 
-interface MIconButtonProps : MButtonBaseProps {
+external interface MIconButtonProps : MButtonBaseProps {
     var disableFocusRipple: Boolean
     var href: String
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/Card.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/Card.kt
@@ -15,7 +15,7 @@ private external val cardModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val cardComponent : RComponent<MCardProps, RState> = cardModule.default
 
-interface MCardProps : StyledProps {
+external interface MCardProps : StyledProps {
     var raised: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardActions.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardActions.kt
@@ -15,7 +15,7 @@ private external val cardActionsModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val cardActionsComponent: RComponent<MCardActionsProps, RState> = cardActionsModule.default
 
-interface MCardActionsProps : StyledProps {
+external interface MCardActionsProps : StyledProps {
     var disableSpacing: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardContent.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardContent.kt
@@ -15,7 +15,7 @@ private external val cardContentModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val cardContentComponent : RComponent<MCardContentProps, RState> = cardContentModule.default
 
-interface MCardContentProps : StyledProps {
+external interface MCardContentProps : StyledProps {
     var component: String
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardHeader.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardHeader.kt
@@ -14,7 +14,7 @@ private external val cardHeaderModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val cardHeaderComponent : RComponent<MCardHeaderProps, RState> = cardHeaderModule.default
 
-interface MCardHeaderProps : StyledProps {
+external interface MCardHeaderProps : StyledProps {
     var action: ReactElement
     var avatar: ReactElement
     var component: String

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardMedia.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/card/CardMedia.kt
@@ -14,7 +14,7 @@ private external val cardMediaModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val cardMediaComponent: RComponent<MCardMediaProps, RState> = cardMediaModule.default
 
-interface MCardMediaProps : StyledProps {
+external interface MCardMediaProps : StyledProps {
     var component: String
     var image: String
     var title: String

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/Dialog.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/Dialog.kt
@@ -24,7 +24,7 @@ enum class DialogScroll {
     paper, body
 }
 
-interface MDialogProps : MModalProps {
+external interface MDialogProps : MModalProps {
     var fullScreen: Boolean
     var fullWidth: Boolean
     var maxWidth: Any

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/DialogActions.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/DialogActions.kt
@@ -15,7 +15,7 @@ private external val dialogActionsModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val dialogActionsComponent: RComponent<MDialogActionsProps, RState> = dialogActionsModule.default
 
-interface MDialogActionsProps : StyledProps {
+external interface MDialogActionsProps : StyledProps {
     var disableSpacing: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/DialogContent.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/DialogContent.kt
@@ -15,7 +15,7 @@ private external val dialogContentModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val dialogContentComponent: RComponent<MDialogContentProps, RState> = dialogContentModule.default
 
-interface MDialogContentProps : StyledProps {
+external interface MDialogContentProps : StyledProps {
     var dividers: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/DialogTitle.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/DialogTitle.kt
@@ -15,7 +15,7 @@ private external val dialogTitleModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val dialogTitleComponent: RComponent<MDialogTitleProps, RState> = dialogTitleModule.default
 
-interface MDialogTitleProps : StyledProps {
+external interface MDialogTitleProps : StyledProps {
     var disableTypography: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/Modal.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/dialog/Modal.kt
@@ -21,7 +21,7 @@ enum class ModalOnCloseReason {
 }
 
 
-interface MModalProps : StyledPropsWithCommonAttributes {
+external interface MModalProps : StyledPropsWithCommonAttributes {
     @JsName("BackdropComponent")
     var backdropComponent: ReactElement
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/expansionpanel/ExpansionPanel.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/expansionpanel/ExpansionPanel.kt
@@ -15,7 +15,7 @@ private external val expansionPanelModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val expansionPanelComponent: RComponent<MExpansionPanelProps, RState> = expansionPanelModule.default
 
-interface MExpansionPanelProps : StyledPropsWithCommonAttributes {
+external interface MExpansionPanelProps : StyledPropsWithCommonAttributes {
 	var defaultExpanded: Boolean
 	var disabled: Boolean
 	var expanded: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/expansionpanel/ExpansionPanelActions.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/expansionpanel/ExpansionPanelActions.kt
@@ -14,7 +14,7 @@ private external val expansionPanelActionsModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val expansionPanelActionsComponent: RComponent<MExpansionPanelActionsProps, RState> = expansionPanelActionsModule.default
 
-interface MExpansionPanelActionsProps : StyledPropsWithCommonAttributes {
+external interface MExpansionPanelActionsProps : StyledPropsWithCommonAttributes {
 	var disableSpacing: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/expansionpanel/ExpansionPanelSummary.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/expansionpanel/ExpansionPanelSummary.kt
@@ -12,7 +12,7 @@ private external val expansionPanelSummaryModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val expansionPanelSummaryComponent: RComponent<MExpansionPanelSummaryProps, RState> = expansionPanelSummaryModule.default
 
-interface MExpansionPanelSummaryProps : StyledPropsWithCommonAttributes {
+external interface MExpansionPanelSummaryProps : StyledPropsWithCommonAttributes {
 	var expandIcon: ReactElement
 	var iconButtonProps: RProps
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormControl.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormControl.kt
@@ -37,7 +37,7 @@ enum class MFormControlMargin {
     none, dense, normal
 }
 
-interface MFormControlProps : StyledPropsWithCommonAttributes {
+external interface MFormControlProps : StyledPropsWithCommonAttributes {
     var disabled: Boolean
     var error: Boolean
     var fullWidth: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormControlLabel.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormControlLabel.kt
@@ -22,7 +22,7 @@ enum class MLabelPlacement {
     end, start, top, bottom
 }
 
-interface MFormControlLabelProps : StyledPropsWithCommonAttributes {
+external interface MFormControlLabelProps : StyledPropsWithCommonAttributes {
     var checked: Boolean
     var control: ReactElement
     var disabled: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormGroup.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormGroup.kt
@@ -19,7 +19,7 @@ private val formGroupComponent: RComponent<MFormGroupProps, RState> = formGroupM
  * From material-ui: FormGroup wraps controls such as Checkbox and Switch. It provides compact row layout. For the Radio,
  * you should be using the RadioGroup component instead of this one.
  */
-interface MFormGroupProps : StyledProps {
+external interface MFormGroupProps : StyledProps {
     var row: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormHelperText.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormHelperText.kt
@@ -17,7 +17,7 @@ private external val formHelperTextModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val formHelperTextComponent: RComponent<MFormHelperTextProps, RState> = formHelperTextModule.default
 
-interface MFormHelperTextProps : StyledProps {
+external interface MFormHelperTextProps : StyledProps {
     var component: String
     var disabled: Boolean
     var error: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormLabel.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/form/FormLabel.kt
@@ -15,7 +15,7 @@ private external val formLabelModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val formLabelComponent: RComponent<MFormLabelProps, RState> = formLabelModule.default
 
-interface MFormLabelProps : StyledPropsWithCommonAttributes {
+external interface MFormLabelProps : StyledPropsWithCommonAttributes {
     var component: String
     var disabled: Boolean
     var error: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/gridlist/GridList.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/gridlist/GridList.kt
@@ -14,7 +14,7 @@ private external val gridListModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val gridListComponent: RComponent<MGridListProps, RState> =gridListModule.default
 
-interface MGridListProps: StyledProps {
+external interface MGridListProps: StyledProps {
 
     @JsName("cellHeight")
     var rawCellHeight: Any

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/gridlist/GridListTile.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/gridlist/GridListTile.kt
@@ -14,7 +14,7 @@ import styled.StyledProps
 private external val gridListTileModule: dynamic
 private val gridListTileComponent: RComponent<MGridListTileProps, RState> =gridListTileModule.default
 
-interface MGridListTileProps: StyledProps {
+external interface MGridListTileProps: StyledProps {
     var cols: Int
     var component: String
     var rows: Int

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/gridlist/GridListTileBar.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/gridlist/GridListTileBar.kt
@@ -25,7 +25,7 @@ enum class MTitlePosition {
     top, bottom
 }
 
-interface MGridListTileBarProps: StyledProps {
+external interface MGridListTileBarProps: StyledProps {
     var actionIcon: ReactElement
     var subtitle: ReactElement
     var title: ReactElement

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/FilledInput.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/FilledInput.kt
@@ -16,7 +16,7 @@ private external val filledInputModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val filledInputComponent: RComponent<MFilledInputProps, RState> = filledInputModule.default
 
-interface MFilledInputProps : MInputBaseProps {
+external interface MFilledInputProps : MInputBaseProps {
     var disableUnderline: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/Input.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/Input.kt
@@ -16,7 +16,7 @@ private external val inputModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val inputComponent: RComponent<MInputProps, RState> = inputModule.default
 
-interface MInputProps : MInputBaseProps {
+external interface MInputProps : MInputBaseProps {
     var disableUnderline: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/InputAdornment.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/InputAdornment.kt
@@ -22,7 +22,7 @@ enum class MInputAdornmentPosition {
     start, end
 }
 
-interface MInputAdornmentProps : StyledProps {
+external interface MInputAdornmentProps : StyledProps {
     var disablePointerEvents: Boolean
     var disableTypography: Boolean
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/InputBase.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/InputBase.kt
@@ -19,7 +19,7 @@ enum class MInputMargin {
  * in inherited interfaces, and since Material UI sometimes changes the onChange function parameters
  * we have created a new base prop for those to inherit from and inherit MInputBaseProps from this as well.
  */
-interface MInputBaseNoOnChangeProps : StyledPropsWithCommonAttributes {
+external interface MInputBaseNoOnChangeProps : StyledPropsWithCommonAttributes {
     var autoComplete: String
     var autoFocus: Boolean
     var defaultValue: String
@@ -46,7 +46,7 @@ interface MInputBaseNoOnChangeProps : StyledPropsWithCommonAttributes {
     var value: Any
 }
 
-interface MInputBaseProps : MInputBaseNoOnChangeProps {
+external interface MInputBaseProps : MInputBaseNoOnChangeProps {
     var onChange: (Event) -> Unit
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/InputLabel.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/InputLabel.kt
@@ -19,7 +19,7 @@ private external val inputLabelModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val inputLabelComponent: RComponent<MInputLabelProps, RState> = inputLabelModule.default
 
-interface MInputLabelProps : MFormLabelProps {
+external interface MInputLabelProps : MFormLabelProps {
     var disableAnimation: Boolean
     var shrink: Boolean
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/OutlinedInput.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/input/OutlinedInput.kt
@@ -16,7 +16,7 @@ private external val outlinedInputModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val outlinedInputComponent: RComponent<MOutlinedInputProps, RState> = outlinedInputModule.default
 
-interface MOutlinedInputProps : MInputBaseProps {
+external interface MOutlinedInputProps : MInputBaseProps {
     var labelWidth: Number
     var notched: Boolean
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/lab/alert/Alert.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/lab/alert/Alert.kt
@@ -27,7 +27,7 @@ enum class MAlertSeverity {
   error, info, success, warning
 }
 
-interface MAlertProps : StyledPropsWithCommonAttributes {
+external interface MAlertProps : StyledPropsWithCommonAttributes {
   var action: ReactElement
   var icon: ReactElement
   var onClose: (Event) -> Unit

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/lab/alert/Alert.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/lab/alert/Alert.kt
@@ -12,10 +12,10 @@ import react.ReactElement
 import styled.StyledHandler
 
 @JsModule("@material-ui/lab/Alert")
-private external val module: dynamic
+private external val alertModule: dynamic
 
 @Suppress("UnsafeCastFromDynamic")
-private val component: RComponent<MAlertProps, RState> = module.default
+private val alertComponent: RComponent<MAlertProps, RState> = alertModule.default
 
 @Suppress("EnumEntryName")
 enum class MAlertVariant {
@@ -46,7 +46,7 @@ fun RBuilder.mAlert(
         addAsChild: Boolean = true,
 
         className: String? = null,
-        handler: StyledHandler<MAlertProps>? = null) = createStyled(component, addAsChild) {
+        handler: StyledHandler<MAlertProps>? = null) = createStyled(alertComponent, addAsChild) {
   message?.let { +message }
   attrs.variant = variant
   attrs.severity = severity
@@ -66,7 +66,7 @@ fun RBuilder.mAlert(
         addAsChild: Boolean = true,
 
         className: String? = null,
-        handler: StyledHandler<MAlertProps>? = null) = createStyled(component, addAsChild) {
+        handler: StyledHandler<MAlertProps>? = null) = createStyled(alertComponent, addAsChild) {
   attrs.variant = variant
   attrs.severity = severity
   attrs.closeText = closeText

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/lab/alert/AlertTitle.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/lab/alert/AlertTitle.kt
@@ -9,16 +9,16 @@ import styled.StyledHandler
 import styled.StyledProps
 
 @JsModule("@material-ui/lab/AlertTitle")
-private external val module: dynamic
+private external val alertTitleModule: dynamic
 
 @Suppress("UnsafeCastFromDynamic")
-private val component: RComponent<StyledProps, RState> = module.default
+private val alertTitleComponent: RComponent<StyledProps, RState> = alertTitleModule.default
 
 fun RBuilder.mAlertTitle(
         title: String,
         addAsChild: Boolean = true,
         className: String? = null,
-        handler: StyledHandler<StyledProps>? = null) = createStyled(component, addAsChild) {
+        handler: StyledHandler<StyledProps>? = null) = createStyled(alertTitleComponent, addAsChild) {
 
     +title
     setStyledPropsAndRunHandler(className, handler)

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/List.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/List.kt
@@ -17,7 +17,7 @@ private external val listModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val listComponent: RComponent<MListProps, RState> = listModule.default
 
-interface MListProps : MButtonBaseProps {
+external interface MListProps : MButtonBaseProps {
     var dense: Boolean
     var disablePadding: Boolean
     var subheader: ReactElement

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/ListItem.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/ListItem.kt
@@ -27,7 +27,7 @@ enum class MListItemAlignItems {
     }
 }
 
-interface MListItemProps : MButtonBaseProps {
+external interface MListItemProps : MButtonBaseProps {
     var button: Boolean
 
     @JsName("ContainerComponent")

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/ListItemText.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/ListItemText.kt
@@ -16,7 +16,7 @@ private external val listItemTextModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 val listItemTextComponent: RComponent<MListItemTextProps, RState> = listItemTextModule.default
 
-interface MListItemTextProps : MButtonBaseProps {
+external interface MListItemTextProps : MButtonBaseProps {
     var disableTypography: Boolean
     var inset: Boolean
     var primary: ReactElement

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/ListSubheader.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/list/ListSubheader.kt
@@ -26,7 +26,7 @@ enum class MListSubheaderColor {
     default, primary, inherit
 }
 
-interface MListSubheaderProps : MButtonBaseProps {
+external interface MListSubheaderProps : MButtonBaseProps {
     var disableGutters: Boolean
     var disableSticky: Boolean
     var inset: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/menu/Menu.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/menu/Menu.kt
@@ -27,7 +27,7 @@ enum class MMenuVariant {
     menu, selectedMenu
 }
 
-interface MMenuProps : MPopoverProps {
+external interface MMenuProps : MPopoverProps {
     var autoFocus: Boolean
 
     @JsName("MenuListProps")

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/menu/MenuItem.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/menu/MenuItem.kt
@@ -16,7 +16,7 @@ private external val menuItemModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val menuItemComponent: RComponent<MMenuItemProps, RState> = menuItemModule.default
 
-interface MMenuItemProps : MListItemProps {
+external interface MMenuItemProps : MListItemProps {
     // Selected has been moved to ListItemProps
     // var selected: Boolean
     var value: String

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/menu/MenuList.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/menu/MenuList.kt
@@ -14,7 +14,7 @@ import styled.StyledHandler
 private external val menuListModule: dynamic
 private val menuList: RComponent<MMenuListProps, RState> = menuListModule.default
 
-interface MMenuListProps : MListProps {
+external interface MMenuListProps : MListProps {
     var disableListWrap: Boolean
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/styles/Spacing.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/styles/Spacing.kt
@@ -3,15 +3,29 @@ package com.ccfraser.muirwik.components.styles
 /**
  * ts2kt types with tweaks from material-ui/styles/spacing
  */
-external interface Spacing {
-    @nativeInvoke
-    operator fun invoke(): Number
-    @nativeInvoke
-    operator fun invoke(value1: Number): Number
-    @nativeInvoke
-    operator fun invoke(value1: Number, value2: Number): String
-    @nativeInvoke
-    operator fun invoke(value1: Number, value2: Number, value3: Number): String
-    @nativeInvoke
-    operator fun invoke(value1: Number, value2: Number, value3: Number, value4: Number): String
+external interface Spacing
+
+@Suppress("NOTHING_TO_INLINE")
+inline operator fun Spacing.invoke(): Number {
+    return asDynamic()() as Number
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline operator fun Spacing.invoke(value1: Number): Number {
+    return asDynamic()(value1) as Number
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline operator fun Spacing.invoke(value1: Number, value2: Number): String {
+    return asDynamic()(value1, value2) as String
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline operator fun Spacing.invoke(value1: Number, value2: Number, value3: Number): String {
+    return asDynamic()(value1, value2, value3) as String
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline operator fun Spacing.invoke(value1: Number, value2: Number, value3: Number, value4: Number): String {
+    return asDynamic()(value1, value2, value3, value4) as String
 }

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/styles/StylesProvider.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/styles/StylesProvider.kt
@@ -18,7 +18,7 @@ private external val jssPresetModule: dynamic
 private external val jss: dynamic
 
 
-interface MStylesProviderProps : RProps {
+external interface MStylesProviderProps : RProps {
     var disableGeneration: Boolean
     var generateClassName: () -> Unit
     var injectFirst: Boolean

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/Table.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/Table.kt
@@ -16,7 +16,7 @@ private external val tableModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val tableComponent: RComponent<MTableProps, RState> = tableModule.default
 
-interface MTableProps : StyledProps {
+external interface MTableProps : StyledProps {
     var component: String
 
     /**

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableBody.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableBody.kt
@@ -15,7 +15,7 @@ private external val tableBodyModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val tableBodyComponent: RComponent<MTableBodyProps, RState> = tableBodyModule.default
 
-interface MTableBodyProps : StyledProps {
+external interface MTableBodyProps : StyledProps {
     var component: String
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableCell.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableCell.kt
@@ -45,7 +45,7 @@ enum class MTableCellSize {
     small, medium
 }
 
-interface MTableCellProps : StyledPropsWithCommonAttributes {
+external interface MTableCellProps : StyledPropsWithCommonAttributes {
     var colSpan: Int
     var component: String
     var key: Any

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableContainer.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableContainer.kt
@@ -15,7 +15,7 @@ private external val tableContainerModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val tableContainerComponent: RComponent<MTableContainerProps, RState> = tableContainerModule.default
 
-interface MTableContainerProps : StyledPropsWithCommonAttributes {
+external interface MTableContainerProps : StyledPropsWithCommonAttributes {
     var component: String
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableFooter.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableFooter.kt
@@ -15,7 +15,7 @@ private external val tableFooterModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val TableFooterComponent: RComponent<MTableFooterProps, RState> = tableFooterModule.default
 
-interface MTableFooterProps : StyledProps {
+external interface MTableFooterProps : StyledProps {
     var component: String
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableHead.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableHead.kt
@@ -15,7 +15,7 @@ private external val tableHeadModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val TableHeadComponent: RComponent<MTableHeadProps, RState> = tableHeadModule.default
 
-interface MTableHeadProps : StyledProps {
+external interface MTableHeadProps : StyledProps {
     var component: String
 }
 

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TablePagination.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TablePagination.kt
@@ -19,7 +19,7 @@ private external val tablePaginationModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val tablePaginationComponent: RComponent<MTablePaginationProps, RState> = tablePaginationModule.default
 
-interface MTablePaginationProps : MButtonBaseProps {
+external interface MTablePaginationProps : MButtonBaseProps {
     @JsName("actions")
     var actions: String
     var backIconButtonProps: MIconButtonProps

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableRow.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableRow.kt
@@ -16,11 +16,10 @@ private external val tableRowModule: dynamic
 @Suppress("UnsafeCastFromDynamic")
 private val tableRowComponent: RComponent<MTableRowProps, RState> = tableRowModule.default
 
-interface MTableRowProps : MButtonBaseProps {
+external interface MTableRowProps : MButtonBaseProps {
     var hover: Boolean
     var key: Any
     var selected: Boolean
-
 }
 
 fun RBuilder.mTableRow(

--- a/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableSortLabel.kt
+++ b/muirwik-components/src/main/kotlin/com/ccfraser/muirwik/components/table/TableSortLabel.kt
@@ -23,7 +23,7 @@ enum class MTableSortLabelDirection {
     asc, desc
 }
 
-interface MTableSortLabelProps : StyledProps {
+external interface MTableSortLabelProps : StyledProps {
     var active: Boolean
 
     @JsName("IconComponent")

--- a/muirwik-testapp/build.gradle.kts
+++ b/muirwik-testapp/build.gradle.kts
@@ -39,12 +39,7 @@ dependencies {
 }
 
 kotlin {
-    println("defaultJsCompileType is $defaultJsCompilerType")
-    defaultJsCompilerType = KotlinJsCompilerType.LEGACY  // The default
-//        defaultJsCompilerType = KotlinJsCompilerType.IR
-//        defaultJsCompilerType = KotlinJsCompilerType.BOTH
-
-    js {
+    js(IR) {
         browser {
             useCommonJs()
 

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/App.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/App.kt
@@ -1,7 +1,6 @@
 package com.ccfraser.muirwik.testapp
 
 import com.ccfraser.muirwik.components.Colors
-import com.ccfraser.muirwik.components.mAppBar
 import com.ccfraser.muirwik.components.mCssBaseline
 import com.ccfraser.muirwik.components.mThemeProvider
 import com.ccfraser.muirwik.components.styles.ThemeOptions

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/App.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/App.kt
@@ -1,13 +1,14 @@
 package com.ccfraser.muirwik.testapp
 
 import com.ccfraser.muirwik.components.Colors
+import com.ccfraser.muirwik.components.mAppBar
 import com.ccfraser.muirwik.components.mCssBaseline
 import com.ccfraser.muirwik.components.mThemeProvider
 import com.ccfraser.muirwik.components.styles.ThemeOptions
 import com.ccfraser.muirwik.components.styles.createMuiTheme
 import react.*
 
-interface AppState: RState {
+external interface AppState: RState {
     var themeColor: String
 }
 

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/App.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/App.kt
@@ -26,7 +26,7 @@ class App(props: RProps) : RComponent<RProps, AppState>(props) {
         themeOptions.palette?.primary.main = Colors.Blue.shade500.toString()
 
         mThemeProvider(createMuiTheme(themeOptions)) {
-            mainFrame("Intro") { setState { themeColor = if (themeColor == "dark") "light" else "dark" } }
+            mainFrame(Page.INTRO) { setState { themeColor = if (themeColor == "dark") "light" else "dark" } }
         }
     }
 }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
@@ -16,12 +16,12 @@ import styled.StyleSheet
 import styled.css
 import styled.styledDiv
 
-interface MainFrameProps : RProps {
+external interface MainFrameProps : RProps {
     var onThemeSwitch: () -> Unit
     var initialView: String
 }
 
-interface MainFrameState: RState {
+external interface MainFrameState: RState {
     var view: String
     var responsiveDrawerOpen: Boolean
 }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
@@ -18,11 +18,11 @@ import styled.styledDiv
 
 external interface MainFrameProps : RProps {
     var onThemeSwitch: () -> Unit
-    var initialView: String
+    var initialView: Page
 }
 
 external interface MainFrameState: RState {
-    var view: String
+    var view: Page
     var responsiveDrawerOpen: Boolean
 }
 
@@ -31,45 +31,6 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
         view = props.initialView
         responsiveDrawerOpen = false
     }
-
-    private val nameToTestMap = hashMapOf(
-            "Intro" to RBuilder::intro,
-            "Accordion" to RBuilder::testAccordion,
-            "App Bar" to RBuilder::testAppBar,
-            "Avatars" to RBuilder::testAvatars,
-            "Badges" to RBuilder::testBadges,
-            "Backdrop" to RBuilder::testBackdrop,
-            "Bottom Nav" to RBuilder::testBottomNavigation,
-            "Breadcrumbs" to RBuilder::testBreadcrumbs,
-            "Buttons" to RBuilder::testButtons,
-            "Cards" to RBuilder::testCards,
-            "Checkboxes" to RBuilder::testCheckboxes,
-            "Chips" to RBuilder::testChips,
-            "ClickAwayListener" to RBuilder::testClickAwayListener,
-            "Dialogs" to RBuilder::testDialogs,
-            "Drawers" to RBuilder::testDrawers,
-            //                            "Gridsto RBuilder::> testGrids,
-            "Grid Lists" to RBuilder::testGridLists,
-            "Lab - Alert" to RBuilder::testLabAlert,
-            "Links" to RBuilder::testLinks,
-            "Lists" to RBuilder::testLists,
-            "Localization" to RBuilder::testLocalization,
-            "Menus" to RBuilder::testMenus,
-            "Popover" to RBuilder::testPopover,
-            "Progress" to RBuilder::testProgress,
-            "Radio Buttons" to RBuilder::testRadioButtons,
-            "Selects" to RBuilder::testSelects,
-            "Sliders" to RBuilder::testSliders,
-            "Snackbars" to RBuilder::testSnackbar,
-            "Styles" to RBuilder::testStyles,
-            "Switches" to RBuilder::testSwitches,
-            "Tables" to RBuilder::testTables,
-            "Tabs" to RBuilder::testTabs,
-            "Text Fields" to RBuilder::testTextFields,
-            "Themes" to RBuilder::testThemes,
-            "Tooltips" to RBuilder::testTooltips,
-            "Transitions" to RBuilder::testTransitions
-    )
 
     override fun RBuilder.render() {
         mCssBaseline()
@@ -99,7 +60,7 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
                             mHidden(mdUp = true, implementation = MHiddenImplementation.css) {
                                 mIconButton("menu", color = MColor.inherit, onClick = { setState { responsiveDrawerOpen = true }})
                             }
-                            mToolbarTitle("Muirwik - Material-UI React Wrapper in Kotlin - Demo (or play) Area - ${ state.view }")
+                            mToolbarTitle("Muirwik - Material-UI React Wrapper in Kotlin - Demo (or play) Area - ${ state.view.title }")
                             mIconButton("lightbulb_outline", onClick = {
                                 props.onThemeSwitch()
                             })
@@ -143,7 +104,7 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
                                 padding(2.spacingUnits)
                                 backgroundColor = Color(theme.palette.background.default)
                             }
-                            nameToTestMap[state.view]?.invoke(this)
+                            state.view.render(this)
                         }
                     }
                 }
@@ -152,14 +113,14 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
     }
 
     private fun RBuilder.demoItems() {
-        fun RBuilder.addListItem(caption: String): Unit {
+        fun RBuilder.addListItem(page: Page): Unit {
 //            mListItem(caption, onClick = {setState {currentView = caption}})
             // We want to get rid of the extra right padding, so must use the longer version as below
-            mListItem(true, onClick = { setState { view = caption; responsiveDrawerOpen = false }}) {
-                mListItemText(caption) {
+            mListItem(true, onClick = { setState { view = page; responsiveDrawerOpen = false }}) {
+                mListItemText(page.title) {
                     css {
                         paddingRight = 0.px
-                        if (caption == state.view) {
+                        if (page == state.view) {
                             descendants {
                                 color = Colors.Blue.shade500
                             }
@@ -183,8 +144,8 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
                     wordBreak = WordBreak.keepAll
                 }
 
-                nameToTestMap.keys.sortedWith { a, b -> if (a == "Intro") -1 else if (b == "Intro") 1 else a.compareTo(b) }
-                        .forEach { addListItem(it) }
+
+                Page.values().forEach { addListItem(it) }
             }
         }
     }
@@ -207,8 +168,46 @@ fun RBuilder.spacer() {
     }
 }
 
+enum class Page(val title: String, val render: RBuilder.() -> ReactElement){
+    INTRO("Intro", RBuilder::intro),
+    ACCORDION("Accordion", RBuilder::testAccordion),
+    APP_BAR("App Bar", RBuilder::testAppBar),
+    AVATARS("Avatars", RBuilder::testAvatars),
+    BADGES("Badges", RBuilder::testBadges),
+    BACKDROP("Backdrop", RBuilder::testBackdrop),
+    BOTTOM_NAV("Bottom Nav", RBuilder::testBottomNavigation),
+    BREADCRUMBS("Breadcrumbs", RBuilder::testBreadcrumbs),
+    BUTTONS("Buttons", RBuilder::testButtons),
+    CARDS("Cards", RBuilder::testCards),
+    CHECKBOXES("Checkboxes", RBuilder::testCheckboxes),
+    CHIPS("Chips", RBuilder::testChips),
+    CLICKAWAYLISTENER("ClickAwayListener", RBuilder::testClickAwayListener),
+    DIALOGS("Dialogs", RBuilder::testDialogs),
+    DRAWERS("Drawers", RBuilder::testDrawers),
+    GRID_LISTS("Grid Lists", RBuilder::testGridLists),
+    LAB_ALERT("Lab - Alert", RBuilder::testLabAlert),
+    LINKS("Links", RBuilder::testLinks),
+    LISTS("Lists", RBuilder::testLists),
+    LOCALIZATION("Localization", RBuilder::testLocalization),
+    MENUS("Menus", RBuilder::testMenus),
+    POPOVER("Popover", RBuilder::testPopover),
+    PROGRESS("Progress", RBuilder::testProgress),
+    RADIO_BUTTONS("Radio Buttons", RBuilder::testRadioButtons),
+    SELECTS("Selects", RBuilder::testSelects),
+    SLIDERS("Sliders", RBuilder::testSliders),
+    SNACKBARS("Snackbars", RBuilder::testSnackbar),
+    STYLES("Styles", RBuilder::testStyles),
+    SWITCHES("Switches", RBuilder::testSwitches),
+    TABLES("Tables", RBuilder::testTables),
+    TABS("Tabs", RBuilder::testTabs),
+    TEXT_FIELDS("Text Fields", RBuilder::testTextFields),
+    THEMES("Themes", RBuilder::testThemes),
+    TOOLTIPS("Tooltips", RBuilder::testTooltips),
+    TRANSITIONS("Transitions", RBuilder::testTransitions);
+}
 
-fun RBuilder.mainFrame(initialView: String, onThemeSwitch: () -> Unit) = child(MainFrame::class) {
+
+fun RBuilder.mainFrame(initialView: Page, onThemeSwitch: () -> Unit) = child(MainFrame::class) {
     attrs.onThemeSwitch = onThemeSwitch
     attrs.initialView = initialView
 }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/MainFrame.kt
@@ -190,6 +190,7 @@ class MainFrame(props: MainFrameProps) : RComponent<MainFrameProps, MainFrameSta
     }
 }
 
+//todo going to IR compiler broke this spacer!
 fun RBuilder.spacer() {
     themeContext.Consumer { theme ->
         val themeStyles = object : StyleSheet("ComponentStyles", isStatic = true) {

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestDrawers.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestDrawers.kt
@@ -256,18 +256,16 @@ class TestDrawers : RComponent<RProps, RState>() {
                         }
                     }
                     mDrawer(miniDrawerOpen, MDrawerAnchor.left, MDrawerVariant.permanent, paperProps = pp) {
-                        div {
-                            attrs.jsStyle = js { display = "flex"; alignItems = "center"; justifyContent = "flex-end"; height = 64 }
+                        styledDiv {
+                            css { display = Display.flex; alignItems = Align.center; justifyContent = JustifyContent.flexEnd; height = 64.px }
                             mIconButton("chevron_left", onClick = { setState { miniDrawerOpen = false } })
                         }
                         mDivider()
                         mailPlaceholder(false)
                     }
-
-                    div {
-                        attrs.jsStyle = js {
-                            flexGrow = 1
-                        }
+//
+                    styledDiv {
+                        css { flexGrow = 1.0 }
                         spacer()
                         mTypography("This is the main content area")
                     }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestRadioButtons.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestRadioButtons.kt
@@ -10,15 +10,20 @@ import styled.StyleSheet
 import styled.css
 import styled.styledDiv
 
-@JsExport
-class TestRadioButtonsState(var gender2Value: String) : RState
+external interface TestRadioButtonsState : RState {
+    var gender2Value: String
+}
+
+private fun testRadioButtonsState(gender2Value: String) = object: TestRadioButtonsState {
+    override var gender2Value: String = gender2Value
+}
 
 class TestRadioButtons : RComponent<RProps, TestRadioButtonsState>() {
     private var radioValue: String = "a"
     private var gender1Value: String = "female"
 
     init {
-        state = TestRadioButtonsState("male")
+        state = testRadioButtonsState("male")
     }
 
     object ComponentStyles : StyleSheet("ComponentStyles", isStatic = true) {

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestRadioButtons.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestRadioButtons.kt
@@ -10,14 +10,15 @@ import styled.StyleSheet
 import styled.css
 import styled.styledDiv
 
-class TestRadioButtons : RComponent<RProps, TestRadioButtons.MyTestState>() {
+@JsExport
+class TestRadioButtonsState(var gender2Value: String) : RState
+
+class TestRadioButtons : RComponent<RProps, TestRadioButtonsState>() {
     private var radioValue: String = "a"
     private var gender1Value: String = "female"
 
-    class MyTestState(var gender2Value: String) : RState
-
     init {
-        state = MyTestState("male")
+        state = TestRadioButtonsState("male")
     }
 
     object ComponentStyles : StyleSheet("ComponentStyles", isStatic = true) {

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTextFields.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTextFields.kt
@@ -15,12 +15,15 @@ import styled.css
 import styled.styledDiv
 import styled.styledForm
 
-class TestTextFields : RComponent<RProps, TestTextFields.MyTestState>() {
+@JsExport
+class TestTextFieldsState(var textValue: String, var multiLineValue: String, var age: Int) : RState
+
+class TestTextFields : RComponent<RProps, TestTextFieldsState>() {
     var name: String = "Name via local var 'state'"
     var selectValue: String = "Item 2"
 
     init {
-        state = MyTestState("", "", 0)
+        state = TestTextFieldsState("", "", 0)
     }
 
     private object ComponentStyles : StyleSheet("ComponentStyles", isStatic = true) {
@@ -158,8 +161,6 @@ class TestTextFields : RComponent<RProps, TestTextFields.MyTestState>() {
         val value = event.targetInputValue
         setState { name = value }
     }
-
-    class MyTestState(var textValue: String, var multiLineValue: String, var age: Int) : RState
 }
 
 

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTextFields.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTextFields.kt
@@ -15,15 +15,24 @@ import styled.css
 import styled.styledDiv
 import styled.styledForm
 
-@JsExport
-class TestTextFieldsState(var textValue: String, var multiLineValue: String, var age: Int) : RState
+external interface TestTextFieldsState : RState {
+    var textValue: String
+    var multiLineValue: String
+    var age: Int
+}
+
+private fun testTextFieldsState(textValue: String, multiLineValue: String,age: Int) = object: TestTextFieldsState {
+    override var textValue: String = textValue
+    override var multiLineValue: String = multiLineValue
+    override var age: Int = age
+}
 
 class TestTextFields : RComponent<RProps, TestTextFieldsState>() {
     var name: String = "Name via local var 'state'"
     var selectValue: String = "Item 2"
 
     init {
-        state = TestTextFieldsState("", "", 0)
+        state = testTextFieldsState("", "", 0)
     }
 
     private object ComponentStyles : StyleSheet("ComponentStyles", isStatic = true) {

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTransitions.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTransitions.kt
@@ -43,8 +43,8 @@ class TestTransitions : RComponent<RProps, RState>() {
                 css(ComponentStyles.area)
                 mFormControlLabel("Collapse", altBuilder.mSwitch(checked = collapseShown, onChange = {_, _ ->  setState {collapseShown = ! collapseShown}}))
 
-                div {
-                    attrs.jsStyle { display = "flex"}
+                styledDiv {
+                    css { display = Display.flex }
                     mCollapse(show = collapseShown) {
                         attrs.timeout = AutoTransitionDuration()
                         mPaper(elevation = 4) { css(paper) }

--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/index.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/index.kt
@@ -1,5 +1,7 @@
 package com.ccfraser.muirwik.testapp
 
+import com.ccfraser.muirwik.components.mAppBar
+import com.ccfraser.muirwik.components.mTypography
 import com.ccfraser.muirwik.components.styles.mStylesProvider
 import kotlinx.browser.document
 import react.dom.render


### PR DESCRIPTION
For a project we are working on I depend on a feature of the new IR compiler. For that reason we need to have this fork which support IR. And as we have already done this work and you have a related issue #37 , we thought we would create a draft PR to share the progress we made with you. From our side this is done, so if you don't want to merge it you can just close it. Otherwise, we can try to make it mergeable together. Let me know what is best for you.

### Unsolved Issues
- The compiler is set to IR and not BOTH, this would be a breaking change for all users and is obviously not acceptable. However, there is a issue with the artefacts if BOTH is used. As I am not efficient in Gradle setups I didn't fix it and just went with IR.
- There are clear issues with styling of the test-app. One instance is that the cushion underneath the app bar does not work anymore and all content is shoved upwards. I did not investigate if there are other issues and just fixed that there are no errors thrown.
- The hot-reloading fails. 

### Solved Issues
- Added external keyword to all interfaces implementing RProps.
- Added @jsExport annotation for all classes implementing RState, or converted them to interfaces where possible.
- Fixed weird naming clash when importing javascript modules. 
- Fixed the Spacing class.
- Replaced usage of div with custom javascript style to styledDiv as it caused errors.

### Added functionality (which could be merged in another PR if this one is discarded)
- Changed paged map to Enum for convenience

### Comments
- I did not have to add @JsExport to classes implementing RComponent, contrary to the suggestion in [this change](https://github.com/JetBrains/kotlin-wrappers/pull/368/files) Intellij warns me to do so.
- I think a next step should be to update Kotlin and the wrappers as there could already be changes to the behaviour I encountered.
