### PR TITLE
Fix adornment issue

### DIFF
--- a/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTextFields.kt
+++ b/muirwik-testapp/src/main/kotlin/com/ccfraser/muirwik/testapp/TestTextFields.kt
@@ -6,6 +6,7 @@ import com.ccfraser.muirwik.components.form.MFormControlVariant
 import com.ccfraser.muirwik.components.input.mInputAdornment
 import com.ccfraser.muirwik.components.menu.mMenuItem
 import com.ccfraser.muirwik.testapp.TestTextFields.ComponentStyles.textField
+import kotlinext.js.jsObject
 import kotlinx.css.*
 import kotlinx.html.InputType
 import org.w3c.dom.events.Event
@@ -159,9 +160,7 @@ class TestTextFields : RComponent<RProps, TestTextFieldsState>() {
             mTextField(label = "Adornment", variant = variant) {
                 css(textField)
                 val adornment = mInputAdornment { +"Kg" }
-                attrs.inputProps = object : RProps {
-                    var startAdornment = adornment
-                }
+                attrs.inputProps = jsObject { this.asDynamic().startAdornment = adornment }
             }
         }
     }


### PR DESCRIPTION
I noticed an issue with the start adornment. My suspicion is that with the new compiler anonymous objects are not compiled the same. The error we get is that the resulting javascript doesn't appear to be what we had before. By changing it the way I did, we can get the same result again.